### PR TITLE
feat: connect + siwe

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "drizzle-orm": "^0.44.3",
         "lucide-react": "^0.526.0",
         "next": "15.4.4",
-        "porto": "^0.0.54",
+        "porto": "^0.0.56",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "server-only": "^0.0.1",
@@ -1234,7 +1234,7 @@
 
     "pony-cause": ["pony-cause@2.1.11", "", {}, "sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg=="],
 
-    "porto": ["porto@0.0.54", "", { "dependencies": { "effect": "^3.16.12", "idb-keyval": "^6.2.1", "mipd": "^0.0.7", "open": "^10.1.0", "ox": "^0.8.4", "zustand": "^5.0.1" }, "peerDependencies": { "@tanstack/react-query": ">=5.59.0", "@wagmi/core": ">=2.16.3", "react": ">=18", "typescript": ">=5.4.0", "viem": ">=2.28.0", "wagmi": ">=2.0.0" }, "optionalPeers": ["@tanstack/react-query", "react", "typescript", "wagmi"], "bin": { "porto": "_dist/cli/bin/index.js" } }, "sha512-Qghx0r7aPlWz7QmhNQEwjgtBmJKXWzxOdNAPk8J4IE7OjQM7r/FVlxNu/GL+Uw8DB7Ug79Rm32XRg3KQSf/wpQ=="],
+    "porto": ["porto@0.0.56", "", { "dependencies": { "effect": "^3.16.12", "idb-keyval": "^6.2.1", "mipd": "^0.0.7", "open": "^10.1.0", "ox": "^0.8.4", "zustand": "^5.0.1" }, "peerDependencies": { "@tanstack/react-query": ">=5.59.0", "@wagmi/core": ">=2.16.3", "react": ">=18", "typescript": ">=5.4.0", "viem": ">=2.28.0", "wagmi": ">=2.0.0" }, "optionalPeers": ["@tanstack/react-query", "react", "typescript", "wagmi"], "bin": { "porto": "_dist/cli/bin/index.js" } }, "sha512-49VtYktD6qOHG3kGYOgTj0KinL0Un9eopfTY5FUU4kZOh9kmaVSKOQwS+ojuunBfUHJ1ELTZPqtxVbN5AqDfXw=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "drizzle-orm": "^0.44.3",
     "lucide-react": "^0.526.0",
     "next": "15.4.4",
-    "porto": "^0.0.54",
+    "porto": "^0.0.56",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "server-only": "^0.0.1",

--- a/src/components/auth/sign-out-button.tsx
+++ b/src/components/auth/sign-out-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { LogOut } from "lucide-react";
-import { authClient } from "@/lib/auth-client";
+import { useDisconnect } from "wagmi";
 
 interface SignOutButtonProps {
   variant?: "default" | "dropdown";
@@ -11,14 +11,12 @@ export const SignOutButton = ({
   variant = "default",
   className,
 }: SignOutButtonProps) => {
-  const handleSignOut = () => {
-    authClient.signOut();
-  };
+  const { disconnect } = useDisconnect();
 
   if (variant === "dropdown") {
     return (
       <div
-        onClick={handleSignOut}
+        onClick={() => disconnect()}
         className={className || "flex items-center cursor-pointer"}
       >
         <LogOut className="mr-2 h-4 w-4" />
@@ -29,7 +27,7 @@ export const SignOutButton = ({
 
   return (
     <button
-      onClick={handleSignOut}
+      onClick={() => disconnect()}
       className={
         className ||
         "flex items-center gap-3 px-4 py-3 text-gray-700 rounded-lg hover:bg-gray-100 transition-colors w-full"

--- a/src/components/features/PortoConnect.tsx
+++ b/src/components/features/PortoConnect.tsx
@@ -2,8 +2,7 @@
 
 import { useAccount, useConnect, useDisconnect } from "wagmi";
 import { Button } from "@/components/ui/button";
-import { authClient } from "@/lib/auth-client";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { Wallet, ShieldCheck, Loader2, LogOut } from "lucide-react";
 import { useSession } from "@/hooks/useSession";
@@ -27,10 +26,11 @@ export function PortoConnect() {
     (connector) => connector.id === "xyz.ithaca.porto",
   )!;
 
-  const signOutMutation = useMutation({
-    mutationFn: () => authClient.signOut(),
-    onSuccess: async () => {
-      await queryClient.invalidateQueries();
+  const signOutMutation = useDisconnect({
+    mutation: {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries();
+      },
     },
   });
 
@@ -108,7 +108,7 @@ export function PortoConnect() {
           </span>
         </div>
         <Button
-          onClick={() => signOutMutation.mutate()}
+          onClick={() => signOutMutation.disconnect()}
           disabled={signOutMutation.isPending}
           variant="ghost"
           size="sm"

--- a/src/components/features/PortoConnect.tsx
+++ b/src/components/features/PortoConnect.tsx
@@ -1,75 +1,31 @@
 "use client";
 
-import { useAccount, useConnect, useDisconnect, useSignMessage } from "wagmi";
+import { useAccount, useConnect, useDisconnect } from "wagmi";
 import { Button } from "@/components/ui/button";
-import { authClient, siweNonce, siweVerify } from "@/lib/auth-client";
-import { createSiweMessage } from "viem/siwe";
+import { authClient } from "@/lib/auth-client";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  Wallet,
-  ShieldCheck,
-  Loader2,
-  AlertCircle,
-  LogOut,
-  Check,
-} from "lucide-react";
 import { useRouter } from "next/navigation";
+import { Wallet, ShieldCheck, Loader2, LogOut } from "lucide-react";
 import { useSession } from "@/hooks/useSession";
-import { cn } from "@/lib/utils";
 
 export function PortoConnect() {
   const account = useAccount();
   const { disconnect } = useDisconnect();
-  const { connectors, connect } = useConnect();
-  const signMessage = useSignMessage();
-  const session = useSession();
   const router = useRouter();
+  const { connectors, connect } = useConnect({
+    mutation: {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries();
+        router.push("/dashboard");
+      },
+    },
+  });
+  const session = useSession();
   const queryClient = useQueryClient();
 
   const connector = connectors.find(
     (connector) => connector.id === "xyz.ithaca.porto",
   )!;
-
-  const signInMutation = useMutation({
-    mutationFn: async () => {
-      if (!account.address) {
-        throw new Error("Address and chainId are required");
-      }
-
-      // 1. Get nonce from server
-      const nonceResponse = await siweNonce(account.address);
-      const nonce = nonceResponse.nonce;
-
-      // 2. Create SIWE message
-      const message = createSiweMessage({
-        address: account.address,
-        chainId: account.chainId!,
-        domain: window.location.host,
-        nonce,
-        uri: window.location.origin,
-        version: "1",
-        statement: "Sign in with Ethereum to Unite DeFi",
-      });
-
-      // 3. Sign message with wallet
-      const signature = await signMessage.signMessageAsync({
-        message,
-      });
-
-      // 4. Verify signature with Better Auth
-      const verifyResponse = await siweVerify({
-        message,
-        signature,
-        walletAddress: account.address,
-      });
-
-      return verifyResponse;
-    },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries();
-      router.push("/dashboard");
-    },
-  });
 
   const signOutMutation = useMutation({
     mutationFn: () => authClient.signOut(),
@@ -81,7 +37,23 @@ export function PortoConnect() {
   // State 1: Not connected to wallet
   if (!account.address) {
     return (
-      <Button onClick={() => connect({ connector })} size="lg">
+      <Button
+        onClick={() =>
+          connect({
+            connector,
+            capabilities: {
+              signInWithEthereum: {
+                authUrl: {
+                  logout: "/api/auth/sign-out",
+                  nonce: "/api/auth/siwe/nonce",
+                  verify: "/api/auth/siwe/verify",
+                },
+              },
+            },
+          })
+        }
+        size="lg"
+      >
         <Wallet className="h-5 w-5" />
         Connect Porto Wallet
       </Button>
@@ -109,26 +81,6 @@ export function PortoConnect() {
             disconnect
           </button>
         </div>
-
-        <Button
-          onClick={() => signInMutation.mutate()}
-          disabled={signInMutation.isPending}
-          className="w-full"
-        >
-          {signInMutation.isPending ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <ShieldCheck className="h-4 w-4" />
-          )}
-          {signInMutation.isPending ? "Signing in..." : "Sign in with Ethereum"}
-        </Button>
-
-        {signInMutation.error && (
-          <div className="flex items-center gap-2 text-xs text-destructive">
-            <AlertCircle className="h-3 w-3 flex-shrink-0" />
-            <span>{signInMutation.error.message}</span>
-          </div>
-        )}
       </div>
     );
   }

--- a/src/config/wagmiConfig.ts
+++ b/src/config/wagmiConfig.ts
@@ -16,3 +16,9 @@ export function getConfig() {
     },
   });
 }
+
+declare module "wagmi" {
+  interface Register {
+    config: ReturnType<typeof getConfig>;
+  }
+}


### PR DESCRIPTION
Added the ability to Connect + SIWE in the one step, instead of requiring the user to connect, and then sign a message.

This PR uses Porto's inferred SIWE mechanism. All that you need to do is make sure that you pass the correct `better-auth` [server endpoints to the `signInWithEthereum.authUrl` field](https://github.com/grmkris/porto-nextjs-better-auth-drizzle/pull/1/files#diff-07132ca6c49f13790f3516e318ae0973f7aa7e5b8b7f170b0cfd5452823658bfR46-R50).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlined the authentication flow by integrating Sign-In with Ethereum (SIWE) directly into the wallet connection process.
* **Bug Fixes**
  * Updated the sign-out functionality to use a more reliable disconnect method.
* **Chores**
  * Updated a dependency to improve compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->